### PR TITLE
Add Verilator support for 16550-based UARTs

### DIFF
--- a/platforms/cpus/max32652.repl
+++ b/platforms/cpus/max32652.repl
@@ -11,9 +11,11 @@ gcr: Miscellaneous.MAX32650_GCR @ sysbus 0x40000000
 
 wdt0: Timers.MAX32650_WDT @ sysbus 0x40003000
     gcr: gcr
+    -> nvic@1
 
 wdt1: Timers.MAX32650_WDT @ sysbus 0x40003400
     gcr: gcr
+    -> nvic@57
 
 timer0: Timers.MAX32650_Timer @ sysbus 0x40010000
     gcr: gcr


### PR DESCRIPTION

### Related issue

[Issue #475 ](https://github.com/renode/renode/issues/475)

### Description

Add a component to the VerilatorIntegrationLibrary that supports UARTs based on the TI 16550 design. The existing UART handler throws an exception due to a difference in how the registers are used in the 16550 design.

I created a UART_16550 class that inherits most of it's functionality from the UART class, but it overrides the write methods that differ in the 16550 part.

This approach should mean that any existing UARTs will not be effected by my changes.

### Usage example
https://github.com/econnellmc/renode-issue-reproduction-template/tree/475-UART_fail

https://github.com/econnellmc/renode-issue-reproduction-template/tree/475-UART_pass

I'm not sure how useful this example is.  I cannot currently share the verilog code that is being compiled into the Vtop executables, so I have had to commit the built binaries.  The difference between the two Vtop is in the Sim_main.cpp, where one of them uses the existing UART class and fails.  The other uses the UART_16550 class and passes.

### Additional information

I need some assistance to get the Robot scripts working correctly.  I got it working locally by running Renode portable which was copied to the local directory.  However, this doesn't gel with the way the github workflow works.

Very happy to make changes based on feedback if there is a different way you'd prefer this to be done.
